### PR TITLE
Report some API calls that are not recommended

### DIFF
--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -18,6 +18,7 @@ enum RuleRegistry {
     "AlwaysUseLowerCamelCase": true,
     "AmbiguousTrailingClosureOverload": true,
     "BeginDocumentationCommentWithOneLineSummary": false,
+    "DisfavoredAPI": true,
     "DoNotUseSemicolons": true,
     "DontRepeatTypeInStaticProperties": true,
     "FileScopedDeclarationPrivacy": true,

--- a/Sources/SwiftFormatRules/DisfavoredAPI.swift
+++ b/Sources/SwiftFormatRules/DisfavoredAPI.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftFormatCore
+@_spi(RawSyntax) import SwiftSyntax
+
+public final class DisfavoredAPI: SyntaxFormatRule {
+
+  let disfavoredAPIs = [
+    // Lower level, these heuristics are less precise as there could still be relevant in some context.
+    "%",
+    // Mid-level, these have been replaced by stdlib alternatives: components(separatedBy:), etc.
+    "componentsSeparatedByString", "rangeOfString", "stringByReplacingOccurrencesOfString",
+    // High-level, there's no reason to use this.
+    "forEach"
+  ]
+
+  public override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+    guard let name = node.calledExpression.lastToken(viewMode: .sourceAccurate)?.with(\.leadingTrivia, []).with(\.trailingTrivia, []) else {
+      return super.visit(node)
+    }
+    if disfavoredAPIs.contains(name.text) {
+      diagnose(.disfavoredAPI(name.text), on: name)
+    }
+    return super.visit(node)
+  }
+}
+
+extension Finding.Message {
+  public static func disfavoredAPI(_ name: String) -> Finding.Message {
+    "avoid using '\(name)'"
+  }
+}

--- a/Sources/SwiftFormatRules/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormatRules/RuleNameCache+Generated.swift
@@ -18,6 +18,7 @@ public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(AlwaysUseLowerCamelCase.self): "AlwaysUseLowerCamelCase",
   ObjectIdentifier(AmbiguousTrailingClosureOverload.self): "AmbiguousTrailingClosureOverload",
   ObjectIdentifier(BeginDocumentationCommentWithOneLineSummary.self): "BeginDocumentationCommentWithOneLineSummary",
+  ObjectIdentifier(DisfavoredAPI.self): "DisfavoredAPI",
   ObjectIdentifier(DoNotUseSemicolons.self): "DoNotUseSemicolons",
   ObjectIdentifier(DontRepeatTypeInStaticProperties.self): "DontRepeatTypeInStaticProperties",
   ObjectIdentifier(FileScopedDeclarationPrivacy.self): "FileScopedDeclarationPrivacy",

--- a/Tests/SwiftFormatRulesTests/DisfavoredAPITests.swift
+++ b/Tests/SwiftFormatRulesTests/DisfavoredAPITests.swift
@@ -1,0 +1,15 @@
+import SwiftFormatRules
+
+final class DisfavoredAPITests: LintOrFormatRuleTestCase {
+  func testSplit() {
+    let input =
+      """
+      "a b c d".componentsSeparatedByString(separator: " ")
+      """
+
+    XCTAssertFormatting(
+      DisfavoredAPI.self, input: input, expected: input, checkForUnassertedDiagnostics: true
+    )
+    XCTAssertDiagnosed(.disfavoredAPI("componentsSeparatedByString"))
+  }
+}


### PR DESCRIPTION
Base logic to report APIs that are discouraged to use. This uses the simple API name as heuristic to find if it's used. We should be careful with shorter names as it could match valid APIs from outside the SDK.

We could expand upon this with a longer list of APIs, like anything that's marked deprecated, unavailable per platform, or the Objective-C name of NS_REFINED_FOR_SWIFT APIs.

We could improve this further with a different score for different levels of how discouraged is an API. Eventually also providing positive scores for encouraged APIs.