### PR TITLE
[Core/Lint] Add a new severity - `refactoring` which is above a `warning`

### DIFF
--- a/Sources/SwiftFormatCore/Finding.swift
+++ b/Sources/SwiftFormatCore/Finding.swift
@@ -16,6 +16,7 @@ public struct Finding {
   public enum Severity {
     case warning
     case error
+    case refactoring
   }
 
   /// The file path and location in that file where a finding was encountered.

--- a/Sources/SwiftFormatCore/Rule.swift
+++ b/Sources/SwiftFormatCore/Rule.swift
@@ -46,6 +46,7 @@ extension Rule {
   public func diagnose<SyntaxType: SyntaxProtocol>(
     _ message: Finding.Message,
     on node: SyntaxType?,
+    severity: Finding.Severity? = nil,
     leadingTriviaIndex: Trivia.Index? = nil,
     notes: [Finding.Note] = []
   ) {
@@ -57,12 +58,12 @@ extension Rule {
       syntaxLocation = node?.startLocation(converter: context.sourceLocationConverter)
     }
 
-    let category = RuleBasedFindingCategory(ruleType: type(of: self))
+    let category = RuleBasedFindingCategory(ruleType: type(of: self), severity: severity)
     context.findingEmitter.emit(
         message,
         category: category,
         location: syntaxLocation.flatMap(Finding.Location.init),
         notes: notes)
-    context.statistics.recordFinding(category.defaultSeverity)
+    context.statistics.recordFinding(category.severity ?? category.defaultSeverity)
   }
 }

--- a/Sources/SwiftFormatCore/RuleBasedFindingCategory.swift
+++ b/Sources/SwiftFormatCore/RuleBasedFindingCategory.swift
@@ -22,8 +22,11 @@ struct RuleBasedFindingCategory: FindingCategorizing {
 
   var description: String { ruleType.ruleName }
 
+  var severity: Finding.Severity?
+
   /// Creates a finding category that wraps the given rule type.
-  init(ruleType: Rule.Type) {
+  init(ruleType: Rule.Type, severity: Finding.Severity? = nil) {
     self.ruleType = ruleType
+    self.severity = severity
   }
 }

--- a/Sources/SwiftFormatCore/Statistics.swift
+++ b/Sources/SwiftFormatCore/Statistics.swift
@@ -22,6 +22,9 @@ public class Statistics {
   /// The number of warnings emitted during processing.
   public private(set) var warnings: Int = 0
 
+  /// The number of refactoring suggestions emitted during processing.
+  public private(set) var refactorings: Int = 0
+
   public func recordStatement() {
     statements += 1
   }
@@ -34,6 +37,7 @@ public class Statistics {
     switch severity {
     case .warning: warnings += instances
     case .error: errors += instances
+    case .refactoring: refactorings += instances
     }
   }
 }

--- a/Sources/SwiftFormatRules/DisfavoredAPI.swift
+++ b/Sources/SwiftFormatRules/DisfavoredAPI.swift
@@ -27,7 +27,7 @@ public final class DisfavoredAPI: SyntaxFormatRule {
       return super.visit(node)
     }
     if disfavoredAPIs.contains(name.text) {
-      diagnose(.disfavoredAPI(name.text), on: name)
+      diagnose(.disfavoredAPI(name.text), on: name, severity: .refactoring)
     }
     return super.visit(node)
   }

--- a/Sources/SwiftFormatRules/NeverUseNonLiteralArrayConstruction.swift
+++ b/Sources/SwiftFormatRules/NeverUseNonLiteralArrayConstruction.swift
@@ -48,7 +48,9 @@ public final class NeverUseNonLiteralArrayConstruction : SyntaxLintRule {
       withFixIt = ": [\(element)] = []"
     }
 
-    diagnose(.refactorLiteralArrayInit(replace: "\(call)", with: withFixIt), on: call.parent)
+    diagnose(.refactorLiteralArrayInit(replace: "\(call)", with: withFixIt),
+             on: call.parent,
+             severity: .refactoring)
     return true
   }
 

--- a/Sources/SwiftFormatRules/ReplaceForEachWithForLoop.swift
+++ b/Sources/SwiftFormatRules/ReplaceForEachWithForLoop.swift
@@ -40,7 +40,7 @@ public final class ReplaceForEachWithForLoop : SyntaxLintRule {
 
     if let closure = node.trailingClosure,
            closure.statements.count == 1 {
-      diagnose(.replaceForEachWithLoop(), on: member)
+      diagnose(.replaceForEachWithLoop(), on: member, severity: .refactoring)
     }
 
     return .visitChildren

--- a/Sources/swift-format/Subcommands/Lint.swift
+++ b/Sources/swift-format/Subcommands/Lint.swift
@@ -40,18 +40,21 @@ extension SwiftFormatCommand {
         var totalStmts = 0
         var totalErrors = 0
         var totalWarnings = 0
+        var totalRefactorings = 0
 
         frontend.processStatistics {
           totalStmts += $1.statements
           totalErrors += $1.errors
           totalWarnings += $1.warnings
+          totalRefactorings += $1.refactorings
         }
 
-        let score = 10.0 - ((5.0 * Double(totalErrors) + Double(totalWarnings)) / Double(totalStmts)) * 10.0
+        let score = 10.0 - ((5.0 * Double(totalErrors) + Double(totalWarnings) + Double(totalRefactorings)) / Double(totalStmts)) * 10.0
         print("----------------------------------")
         print("-- Total Statements: \(totalStmts)")
         print("-- Total Errors: \(totalErrors)")
         print("-- Total Warnings: \(totalWarnings)")
+        print("-- Total Refactorings: \(totalRefactorings)")
         print("-- Score: \(score)")
       }
 

--- a/Sources/swift-format/Utilities/DiagnosticsEngine.swift
+++ b/Sources/swift-format/Utilities/DiagnosticsEngine.swift
@@ -116,6 +116,7 @@ final class DiagnosticsEngine {
     switch finding.severity {
     case .error: severity = .error
     case .warning: severity = .warning
+    case .refactoring: severity = .warning
     }
     return Diagnostic(
       severity: severity,


### PR DESCRIPTION
Move a few linting rules to use the new `refactoring` severity:

- Literal array construction
- `.forEach { ... }` use
- Disfavored APIs

are all actionable refactorings.