### PR TITLE
[Lint] Add a rule to detect that type declarations are not capitalized

### DIFF
--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -51,6 +51,7 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
@@ -109,6 +110,7 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(FullyIndirectEnum.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     visitIfEnabled(OneCasePerLine.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
@@ -228,6 +230,7 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
@@ -263,6 +266,7 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseSynthesizedInitializer.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -44,6 +44,7 @@ enum RuleRegistry {
     "OrderedImports": true,
     "ReplaceForEachWithForLoop": true,
     "ReturnVoidInsteadOfEmptyTuple": true,
+    "TypeNamesShouldBeCapitalized": true,
     "UseEarlyExits": false,
     "UseLetInEveryBoundCaseVariable": true,
     "UseShorthandTypeNames": true,

--- a/Sources/SwiftFormatCore/Finding.swift
+++ b/Sources/SwiftFormatCore/Finding.swift
@@ -17,6 +17,7 @@ public struct Finding {
     case warning
     case error
     case refactoring
+    case convention
   }
 
   /// The file path and location in that file where a finding was encountered.

--- a/Sources/SwiftFormatCore/Statistics.swift
+++ b/Sources/SwiftFormatCore/Statistics.swift
@@ -25,6 +25,9 @@ public class Statistics {
   /// The number of refactoring suggestions emitted during processing.
   public private(set) var refactorings: Int = 0
 
+  /// The number of convention errors emitted during processing.
+  public private(set) var conventions: Int = 0
+
   public func recordStatement() {
     statements += 1
   }
@@ -38,6 +41,7 @@ public class Statistics {
     case .warning: warnings += instances
     case .error: errors += instances
     case .refactoring: refactorings += instances
+    case .convention: conventions += instances
     }
   }
 }

--- a/Sources/SwiftFormatRules/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormatRules/RuleNameCache+Generated.swift
@@ -44,6 +44,7 @@ public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(OrderedImports.self): "OrderedImports",
   ObjectIdentifier(ReplaceForEachWithForLoop.self): "ReplaceForEachWithForLoop",
   ObjectIdentifier(ReturnVoidInsteadOfEmptyTuple.self): "ReturnVoidInsteadOfEmptyTuple",
+  ObjectIdentifier(TypeNamesShouldBeCapitalized.self): "TypeNamesShouldBeCapitalized",
   ObjectIdentifier(UseEarlyExits.self): "UseEarlyExits",
   ObjectIdentifier(UseLetInEveryBoundCaseVariable.self): "UseLetInEveryBoundCaseVariable",
   ObjectIdentifier(UseShorthandTypeNames.self): "UseShorthandTypeNames",

--- a/Sources/SwiftFormatRules/TypeNamesShouldBeCapitalized.swift
+++ b/Sources/SwiftFormatRules/TypeNamesShouldBeCapitalized.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftFormatCore
+import SwiftSyntax
+
+/// `struct`, `class`, `enum` and `protocol` declarations should have a capitalized name.
+///
+/// Lint:  Types with un-capitalized names will yield a lint error.
+public final class TypeNamesShouldBeCapitalized : SyntaxLintRule {
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.identifier)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.identifier)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.identifier)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.identifier)
+    return .visitChildren
+  }
+
+  private func diagnoseNameConventionMismatch<T: DeclSyntaxProtocol>(_ type: T, name: TokenSyntax) {
+    if let firstChar = name.text.first, !firstChar.isUppercase {
+      diagnose(.capitalizeTypeName(name: name.text), on: type, severity: .convention)
+    }
+  }
+}
+
+extension Finding.Message {
+  public static func capitalizeTypeName(name: String) -> Finding.Message {
+    let capitalized = name.prefix(1).uppercased() + name.dropFirst()
+    return "type names should be capitalized: \(name) -> \(capitalized)"
+  }
+}

--- a/Sources/swift-format/Subcommands/Lint.swift
+++ b/Sources/swift-format/Subcommands/Lint.swift
@@ -41,20 +41,23 @@ extension SwiftFormatCommand {
         var totalErrors = 0
         var totalWarnings = 0
         var totalRefactorings = 0
+        var totalConventions = 0
 
         frontend.processStatistics {
           totalStmts += $1.statements
           totalErrors += $1.errors
           totalWarnings += $1.warnings
           totalRefactorings += $1.refactorings
+          totalConventions += $1.conventions
         }
 
-        let score = 10.0 - ((5.0 * Double(totalErrors) + Double(totalWarnings) + Double(totalRefactorings)) / Double(totalStmts)) * 10.0
+        let score = 10.0 - ((5.0 * Double(totalErrors) + Double(totalWarnings) + Double(totalRefactorings) + Double(totalConventions)) / Double(totalStmts)) * 10.0
         print("----------------------------------")
         print("-- Total Statements: \(totalStmts)")
         print("-- Total Errors: \(totalErrors)")
         print("-- Total Warnings: \(totalWarnings)")
         print("-- Total Refactorings: \(totalRefactorings)")
+        print("-- Total Conventions: \(totalConventions)")
         print("-- Score: \(score)")
       }
 

--- a/Sources/swift-format/Utilities/DiagnosticsEngine.swift
+++ b/Sources/swift-format/Utilities/DiagnosticsEngine.swift
@@ -117,6 +117,7 @@ final class DiagnosticsEngine {
     case .error: severity = .error
     case .warning: severity = .warning
     case .refactoring: severity = .warning
+    case .convention: severity = .warning
     }
     return Diagnostic(
       severity: severity,

--- a/Tests/SwiftFormatRulesTests/TypeNamesShouldBeCapitalizedTests.swift
+++ b/Tests/SwiftFormatRulesTests/TypeNamesShouldBeCapitalizedTests.swift
@@ -1,0 +1,27 @@
+import SwiftFormatRules
+
+final class TypeNamesShouldBeCapitalizedTests: LintOrFormatRuleTestCase {
+  func testConstruction() {
+    let input =
+      """
+      struct a {}
+      class klassName {
+        struct subType {}
+      }
+      protocol myProtocol {}
+
+      extension myType {
+        struct innerType {}
+      }
+      """
+
+    performLint(TypeNamesShouldBeCapitalized.self, input: input)
+
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "a"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "klassName"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "subType"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "myProtocol"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "myType"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "innerType"))
+  }
+}


### PR DESCRIPTION
- Adds `convention` severity which applies to established language convention rules
- Adds a rule to check that all type declarations (class/struct/enum/protocol) start with uppercase letter.